### PR TITLE
Add diagnostics summaries for CI matrix jobs

### DIFF
--- a/.github/scripts/aggregator.js
+++ b/.github/scripts/aggregator.js
@@ -27,24 +27,15 @@ try {
       const full = path.join(dir, entry.name);
       if (entry.isDirectory()) {
         loadFiles(full);
-      } else if (entry.name.endsWith("-diagnostics.json")) {
-        processedFiles.push(`✔️ Diagnostics: ${full}`);
-        try {
-          const data = JSON.parse(fs.readFileSync(full, "utf-8"));
-          data.__file = full;
-          const schemaError = validateSchema(full);
-          if (schemaError) {
-            data.schema_error = schemaError;
-            data.status = "failure";
-          }
-          allReports.push(data);
-        } catch (e) {
-          schemaFailures++;
-          allReports.push({ job: full, status: "failure", errors: 1, warnings: 0, messages: [{ type: "error", message: `Failed to parse diagnostics: ${e.message}` }], schema_error: e.toString() });
-        }
-      } else if (entry.name.endsWith("-fallback.json")) {
+        continue;
+      }
+
+      if (!entry.name.endsWith(".json")) continue;
+
+      const isFallback = entry.name.endsWith("-fallback.json");
+      if (isFallback) {
         processedFiles.push(`⚠️ Fallback: ${full}`);
-        if (!allReports.some(r => r.__file && r.__file.includes(entry.name.replace("-fallback.json", "-diagnostics.json")))) {
+        if (!allReports.some(r => r.__file && r.__file.includes(entry.name.replace("-fallback.json", "")))) {
           try {
             const data = JSON.parse(fs.readFileSync(full, "utf-8"));
             data.__file = full;
@@ -54,6 +45,22 @@ try {
             allReports.push({ job: full, status: "failure", errors: 1, warnings: 0, messages: [{ type: "error", message: `Failed to parse fallback: ${e.message}` }] });
           }
         }
+        continue;
+      }
+
+      processedFiles.push(`✔️ Summary: ${full}`);
+      try {
+        const data = JSON.parse(fs.readFileSync(full, "utf-8"));
+        data.__file = full;
+        const schemaError = validateSchema(full);
+        if (schemaError) {
+          data.schema_error = schemaError;
+          data.status = "failure";
+        }
+        allReports.push(data);
+      } catch (e) {
+        schemaFailures++;
+        allReports.push({ job: full, status: "failure", errors: 1, warnings: 0, messages: [{ type: "error", message: `Failed to parse diagnostics: ${e.message}` }], schema_error: e.toString() });
       }
     }
   }
@@ -61,19 +68,19 @@ try {
   loadFiles(baseDir);
 
   const expectedJobs = [
-    "frontend-checks/eslint",
-    "frontend-checks/prettier",
-    "frontend-checks/tsc",
-    "frontend-checks/jest-unit",
-    "frontend-checks/playwright-e2e",
-    "backend-checks/pytest",
-    "backend-checks/mypy",
-    "backend-checks/flake8",
-    "backend-checks/black",
-    "coverage-checks/frontend",
-    "coverage-checks/backend",
-    "coverage-checks/backend-node",
-    "coverage-checks/e2e"
+    "frontend-checks_lint",
+    "frontend-checks_prettier",
+    "frontend-checks_type-check",
+    "frontend-checks_test-unit",
+    "frontend-checks_playwright-e2e",
+    "backend-checks_black",
+    "backend-checks_flake8",
+    "backend-checks_mypy",
+    "backend-checks_pytest",
+    "coverage-checks_frontend",
+    "coverage-checks_backend",
+    "coverage-checks_backend-node",
+    "coverage-checks_e2e"
   ];
 
   expectedJobs.forEach(job => {
@@ -86,24 +93,31 @@ try {
   let totalWarnings = 0;
   let totalCoverageLines = { covered: 0, missed: 0 };
 
-  let summaryTable = "### 📊 Summary Table\n\n| Job | Errors | Warnings | Status | Schema Valid |\n|-----|--------|----------|--------|--------------|\n";
-  let metadataTable = "\n### 🛠 Tool Metadata\n\n| Job | Tool | Version | Exit Code | Duration | Fallback |\n|-----|------|---------|-----------|----------|----------|\n";
+  let summaryTable = "### 📊 Summary Table\n\n| Job | Status | Exit Code | Schema Valid |\n|-----|--------|-----------|--------------|\n";
+  let metadataTable = "\n### 🛠 Tool Metadata\n\n| Job | Tool | Version | Runner | OS |\n|-----|------|---------|--------|----|\n";
 
   let errorsSection = "\n### ❌ Consolidated Errors\n";
   let warningsSection = "\n### ⚠️ Consolidated Warnings\n";
   let failedTestsSection = "\n### 🧨 Consolidated Test Failures\n";
-  let processedSection = "\n### 📂 Files Processed\n" + processedFiles.join("\n");
+  const processedList = processedFiles.length ? processedFiles.join("\n") : "No summary files discovered.";
+  let processedSection = "\n### 📂 Files Processed\n" + processedList;
 
   for (const r of allReports) {
-    const errors = Number.isInteger(r.errors) ? r.errors : (r.errors?.length || 0);
-    const warnings = Number.isInteger(r.warnings) ? r.warnings : (r.warnings?.length || 0);
+    const errors = Number.isInteger(r.errors)
+      ? r.errors
+      : (Array.isArray(r.errors) ? r.errors.length : 0);
+    const warnings = Number.isInteger(r.warnings)
+      ? r.warnings
+      : (Array.isArray(r.warnings) ? r.warnings.length : 0);
 
     totalErrors += errors;
     totalWarnings += warnings;
 
-    summaryTable += `| ${r.job || r.__file} | ${errors} | ${warnings} | ${r.status || "?"} | ${r.schema_error ? "❌" : "✅"} |\n`;
+    const status = r.status || "?";
+    const exitCode = Number.isInteger(r.exit_code) ? r.exit_code : r.exit_code ?? "?";
+    summaryTable += `| ${r.job || r.__file} | ${status} | ${exitCode} | ${r.schema_error ? "❌" : "✅"} |\n`;
 
-    metadataTable += `| ${r.job || r.__file} | ${r.metadata?.tool || "?"} | ${r.metadata?.version || "?"} | ${r.exit_code ?? "?"} | ${r.metadata?.duration || "?"} | ${r.metadata?.fallback || false} |\n`;
+    metadataTable += `| ${r.job || r.__file} | ${r.metadata?.tool || "?"} | ${r.metadata?.version || "?"} | ${r.environment?.runner || "?"} | ${r.environment?.os || "?"} |\n`;
 
     if (errors > 0) errorsSection += `- ${r.job}: ${errors} errors reported\n`;
     if (warnings > 0) warningsSection += `- ${r.job}: ${warnings} warnings reported\n`;

--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -38,20 +38,83 @@ jobs:
           echo "memory_mb=$(free -m | awk '/Mem:/ {print $2}')" >> $GITHUB_OUTPUT
           echo "disk_free_mb=$(df -m . | awk 'NR==2 {print $4}')" >> $GITHUB_OUTPUT
 
-      - name: Ensure summaries dir always exists
-        run: mkdir -p summaries
-
-      - name: Validate summaries before upload
-        if: always()
+      - name: Run ${{ matrix.task }}
+        id: run_task
+        continue-on-error: true
+        shell: bash
         run: |
-          echo "📂 Summaries before upload (${{ matrix.task }}):"
-          ls -lah summaries || echo "❌ summaries/ not found"
+          set -o pipefail
+          TASK="${{ matrix.task }}"
+          set +e
+          EXIT_CODE=0
+          case "$TASK" in
+            black)
+              black --check .
+              EXIT_CODE=$?
+              ;;
+            flake8)
+              flake8
+              EXIT_CODE=$?
+              ;;
+            mypy)
+              mypy .
+              EXIT_CODE=$?
+              ;;
+            pytest)
+              pytest
+              EXIT_CODE=$?
+              ;;
+            *)
+              echo "Unknown backend task: $TASK" >&2
+              EXIT_CODE=1
+              ;;
+          esac
+          set -e
+          STATUS="success"
+          if [ "$EXIT_CODE" -ne 0 ]; then STATUS="failure"; fi
+          echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
+          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
+          exit "$EXIT_CODE"
 
-      - name: Upload backend summaries (unified)
+      - name: 📦 Write diagnostics JSON
+        if: always()
+        shell: bash
+        run: |
+          SCOPE="backend"
+          JOB_KEY="backend-checks_${{ matrix.task }}"
+          EXIT_CODE="${{ steps.run_task.outputs.exit_code }}"
+          STATUS="${{ steps.run_task.outputs.status }}"
+          if [ -z "$EXIT_CODE" ]; then EXIT_CODE=1; fi
+          if [ -z "$STATUS" ]; then STATUS="success"; fi
+          if [ "$EXIT_CODE" -ne 0 ]; then STATUS="failure"; fi
+          mkdir -p "summaries/$SCOPE"
+          tee "summaries/$SCOPE/${JOB_KEY}.json" <<EOF
+{
+  "job": "${JOB_KEY}",
+  "status": "${STATUS}",
+  "exit_code": ${EXIT_CODE},
+  "metadata": {
+    "tool": "${{ matrix.task }}",
+    "version": "1.0.0"
+  },
+  "environment": {
+    "runner": "Hosted Agent",
+    "os": "ubuntu-latest"
+  },
+  "dependencies": {
+    "npm": []
+  }
+}
+EOF
+          ls -lah "summaries/$SCOPE"
+          cat "summaries/$SCOPE/${JOB_KEY}.json"
+          if [ "$EXIT_CODE" -ne 0 ]; then exit "$EXIT_CODE"; fi
+
+      - name: Upload diagnostics summary
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: backend-summaries
+          name: diagnostics-summary-backend-checks_${{ matrix.task }}
           path: summaries/
           retention-days: 2
           if-no-files-found: error

--- a/.github/workflows/ci-diagnostics.yml
+++ b/.github/workflows/ci-diagnostics.yml
@@ -15,23 +15,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Download frontend summaries
+      - name: Download diagnostics summaries
         uses: actions/download-artifact@v4
         with:
-          name: frontend-summaries
-          path: ./summaries/frontend
-
-      - name: Download backend summaries
-        uses: actions/download-artifact@v4
-        with:
-          name: backend-summaries
-          path: ./summaries/backend
-
-      - name: Download coverage summaries
-        uses: actions/download-artifact@v4
-        with:
-          name: coverage-summaries
-          path: ./summaries/coverage
+          pattern: diagnostics-summary-*
+          path: .
+          merge-multiple: true
 
       - name: Install aggregator dependencies in isolated dir
         shell: bash

--- a/.github/workflows/coverage-checks.yml
+++ b/.github/workflows/coverage-checks.yml
@@ -67,20 +67,71 @@ jobs:
           echo "memory_mb=$(free -m | awk '/Mem:/ {print $2}')" >> $GITHUB_OUTPUT
           echo "disk_free_mb=$(df -m . | awk 'NR==2 {print $4}')" >> $GITHUB_OUTPUT
 
-      - name: Ensure summaries dir always exists
-        run: mkdir -p summaries
-
-      - name: Validate summaries before upload
-        if: always()
+      - name: Run ${{ matrix.task }} coverage
+        id: run_task
+        continue-on-error: true
+        shell: bash
         run: |
-          echo "📂 Summaries before upload (${{ matrix.task }}):"
-          ls -lah summaries || echo "❌ summaries/ not found"
+          set -o pipefail
+          TASK="${{ matrix.task }}"
+          SCRIPT="coverage:${{ matrix.task }}"
+          STATUS="success"
+          EXIT_CODE=0
+          set +e
+          export SCRIPT
+          if node -e "const pkg=require('./package.json'); const script=process.env.SCRIPT; process.exit(pkg.scripts && Object.prototype.hasOwnProperty.call(pkg.scripts, script) ? 0 : 1);"; then
+            pnpm run "$SCRIPT"
+            EXIT_CODE=$?
+            if [ "$EXIT_CODE" -ne 0 ]; then STATUS="failure"; fi
+          else
+            echo "No script $SCRIPT defined. Skipping execution." >&2
+            STATUS="skipped"
+            EXIT_CODE=0
+          fi
+          set -e
+          echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
+          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
+          exit "$EXIT_CODE"
 
-      - name: Upload coverage summaries (unified)
+      - name: 📦 Write diagnostics JSON
+        if: always()
+        shell: bash
+        run: |
+          SCOPE="coverage"
+          JOB_KEY="coverage-checks_${{ matrix.task }}"
+          EXIT_CODE="${{ steps.run_task.outputs.exit_code }}"
+          STATUS="${{ steps.run_task.outputs.status }}"
+          if [ -z "$EXIT_CODE" ]; then EXIT_CODE=1; fi
+          if [ -z "$STATUS" ]; then STATUS="success"; fi
+          if [ "$EXIT_CODE" -ne 0 ] && [ "$STATUS" = "success" ]; then STATUS="failure"; fi
+          mkdir -p "summaries/$SCOPE"
+          tee "summaries/$SCOPE/${JOB_KEY}.json" <<EOF
+{
+  "job": "${JOB_KEY}",
+  "status": "${STATUS}",
+  "exit_code": ${EXIT_CODE},
+  "metadata": {
+    "tool": "${{ matrix.task }}",
+    "version": "1.0.0"
+  },
+  "environment": {
+    "runner": "Hosted Agent",
+    "os": "ubuntu-latest"
+  },
+  "dependencies": {
+    "npm": []
+  }
+}
+EOF
+          ls -lah "summaries/$SCOPE"
+          cat "summaries/$SCOPE/${JOB_KEY}.json"
+          if [ "$EXIT_CODE" -ne 0 ]; then exit "$EXIT_CODE"; fi
+
+      - name: Upload diagnostics summary
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-summaries
+          name: diagnostics-summary-coverage-checks_${{ matrix.task }}
           path: summaries/
           retention-days: 2
           if-no-files-found: error

--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -32,32 +32,60 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run ${{ matrix.task }}
-        run: pnpm run checks:${{ matrix.task }}
-
-      - name: 📦 Write diagnostics JSON (if applicable)
-        if: matrix.task == 'playwright-e2e' || matrix.task == 'test-unit'
-        run: |
-          mkdir -p summaries/frontend
-          FILE="summaries/frontend/frontend-checks_${{ matrix.task }}.json"
-          echo "🧾 Writing summary for ${{ matrix.task }} to $FILE"
-          echo '{
-            "job": "frontend-checks/${{ matrix.task }}",
-            "status": "success",
-            "exit_code": 0,
-            "metadata": {"tool": "${{ matrix.task }}", "version": "1.0.0"},
-            "environment": {"runner": "Hosted Agent", "os": "ubuntu-latest"},
-            "dependencies": {"npm": []}
-          }' | tee "$FILE"
-          echo "📂 Listing contents:"
-          ls -lah summaries/frontend || echo "no summaries written"
-          echo "📄 JSON contents:" && cat "$FILE"
+        id: run_task
+        continue-on-error: true
         shell: bash
+        run: |
+          set -o pipefail
+          set +e
+          pnpm run checks:${{ matrix.task }}
+          EXIT_CODE=$?
+          set -e
+          STATUS="success"
+          if [ "$EXIT_CODE" -ne 0 ]; then STATUS="failure"; fi
+          echo "exit_code=$EXIT_CODE" >> "$GITHUB_OUTPUT"
+          echo "status=$STATUS" >> "$GITHUB_OUTPUT"
+          exit "$EXIT_CODE"
 
-      - name: 🚀 Upload summary (if applicable)
-        if: matrix.task == 'playwright-e2e' || matrix.task == 'test-unit'
+      - name: 📦 Write diagnostics JSON
+        if: always()
+        shell: bash
+        run: |
+          SCOPE="frontend"
+          JOB_KEY="frontend-checks_${{ matrix.task }}"
+          EXIT_CODE="${{ steps.run_task.outputs.exit_code }}"
+          STATUS="${{ steps.run_task.outputs.status }}"
+          if [ -z "$EXIT_CODE" ]; then EXIT_CODE=1; fi
+          if [ -z "$STATUS" ]; then STATUS="success"; fi
+          if [ "$EXIT_CODE" -ne 0 ]; then STATUS="failure"; fi
+          mkdir -p "summaries/$SCOPE"
+          tee "summaries/$SCOPE/${JOB_KEY}.json" <<EOF
+{
+  "job": "${JOB_KEY}",
+  "status": "${STATUS}",
+  "exit_code": ${EXIT_CODE},
+  "metadata": {
+    "tool": "${{ matrix.task }}",
+    "version": "1.0.0"
+  },
+  "environment": {
+    "runner": "Hosted Agent",
+    "os": "ubuntu-latest"
+  },
+  "dependencies": {
+    "npm": []
+  }
+}
+EOF
+          ls -lah "summaries/$SCOPE"
+          cat "summaries/$SCOPE/${JOB_KEY}.json"
+          if [ "$EXIT_CODE" -ne 0 ]; then exit "$EXIT_CODE"; fi
+
+      - name: Upload diagnostics summary
+        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: frontend-partial-${{ matrix.task }}
+          name: diagnostics-summary-frontend-checks_${{ matrix.task }}
           path: summaries/
           retention-days: 2
           if-no-files-found: error

--- a/diagnostics.schema.json
+++ b/diagnostics.schema.json
@@ -1,157 +1,45 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Diagnostics Schema",
+  "title": "Diagnostics Summary",
   "type": "object",
   "required": [
     "job",
-    "exit_code",
     "status",
-    "errors",
-    "warnings",
-    "artifacts",
+    "exit_code",
     "metadata",
-    "environment"
+    "environment",
+    "dependencies"
   ],
   "properties": {
     "job": { "type": "string" },
-    "exit_code": { "type": "integer" },
     "status": { "type": "string", "enum": ["success", "failure", "warning", "skipped"] },
-    "errors": { "type": "integer", "minimum": 0 },
-    "warnings": { "type": "integer", "minimum": 0 },
-    "messages": {
-      "type": "array",
-      "description": "Detailed messages from tool outputs",
-      "items": {
-        "type": "object",
-        "required": ["type", "message"],
-        "properties": {
-          "type": { "type": "string", "enum": ["error", "warning", "notice"] },
-          "message": { "type": "string" },
-          "file": { "type": "string" },
-          "line": { "type": "integer" },
-          "column": { "type": "integer" },
-          "rule": { "type": "string" },
-          "stack": { "type": "string" }
-        }
-      }
-    },
-    "annotations": {
-      "type": "array",
-      "description": "Annotations pulled from GitHub Actions API",
-      "items": {
-        "type": "object",
-        "properties": {
-          "annotation_level": { "type": "string", "enum": ["failure", "warning", "notice"] },
-          "message": { "type": "string" },
-          "path": { "type": "string" },
-          "start_line": { "type": "integer" },
-          "end_line": { "type": "integer" },
-          "title": { "type": "string" }
-        }
-      }
-    },
-    "tests": {
-      "type": "array",
-      "description": "Detailed test case results",
-      "items": {
-        "type": "object",
-        "required": ["name", "status"],
-        "properties": {
-          "name": { "type": "string" },
-          "status": { "type": "string", "enum": ["passed", "failed", "skipped"] },
-          "duration": { "type": "string" },
-          "message": { "type": "string" },
-          "file": { "type": "string" },
-          "line": { "type": "integer" },
-          "stack": { "type": "string" }
-        }
-      }
-    },
-    "coverage": {
-      "type": "object",
-      "description": "Coverage details per job",
-      "properties": {
-        "lines": {
-          "type": "object",
-          "properties": {
-            "covered": { "type": "integer" },
-            "missed": { "type": "integer" },
-            "pct": { "type": "number" }
-          }
-        },
-        "branches": {
-          "type": "object",
-          "properties": {
-            "covered": { "type": "integer" },
-            "missed": { "type": "integer" },
-            "pct": { "type": "number" }
-          }
-        },
-        "files": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "path": { "type": "string" },
-              "lines_pct": { "type": "number" },
-              "branches_pct": { "type": "number" }
-            }
-          }
-        }
-      }
-    },
-    "artifacts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": ["name", "path"],
-        "properties": {
-          "name": { "type": "string" },
-          "path": { "type": "string" },
-          "url": { "type": "string" }
-        }
-      }
-    },
+    "exit_code": { "type": "integer" },
     "metadata": {
       "type": "object",
+      "required": ["tool", "version"],
       "properties": {
         "tool": { "type": "string" },
-        "version": { "type": "string" },
-        "duration": { "type": "string" },
-        "sha256": { "type": "string" },
-        "fallback": { "type": "boolean" }
+        "version": { "type": "string" }
       }
     },
     "environment": {
       "type": "object",
+      "required": ["runner", "os"],
       "properties": {
         "runner": { "type": "string" },
-        "os": { "type": "string" },
-        "node": { "type": "string" },
-        "python": { "type": "string" },
-        "pnpm": { "type": "string" },
-        "git_sha": { "type": "string" },
-        "job_started": { "type": "string", "format": "date-time" },
-        "job_ended": { "type": "string", "format": "date-time" }
+        "os": { "type": "string" }
       }
     },
     "dependencies": {
       "type": "object",
-      "description": "Snapshot of dependencies and lockfile",
+      "required": ["npm"],
       "properties": {
-        "lockfile_sha": { "type": "string" },
-        "npm": { "type": "object" },
-        "pip": { "type": "object" }
-      }
-    },
-    "resources": {
-      "type": "object",
-      "description": "System resource info",
-      "properties": {
-        "cpu_count": { "type": "integer" },
-        "memory_mb": { "type": "integer" },
-        "disk_free_mb": { "type": "integer" }
+        "npm": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
       }
     }
-  }
+  },
+  "additionalProperties": true
 }


### PR DESCRIPTION
## Summary
- capture command exit codes in every frontend/backend/coverage matrix job and emit diagnostics JSON under the new naming convention
- upload per-job diagnostics artifacts and teach the CI diagnostics workflow to download the new artifacts
- update the diagnostics aggregator and JSON schema to parse the simplified summaries and expect the refreshed job keys

## Testing
- not run (workflow changes only)


------
https://chatgpt.com/codex/tasks/task_e_68d17927162883218dbf9892a3d69f79