### PR TITLE
Align diagnostics summaries with Codex schema

### DIFF
--- a/.github/scripts/aggregator.js
+++ b/.github/scripts/aggregator.js
@@ -3,16 +3,25 @@ const path = require("path");
 const { execSync } = require("child_process");
 
 try {
-  const baseDir = "summaries";
+  const workspaceDir = process.env.GITHUB_WORKSPACE || process.cwd();
+  const baseDir = path.join(workspaceDir, "summaries");
+  const schemaPath = path.join(workspaceDir, "diagnostics.schema.json");
+  const localAjv = path.join(workspaceDir, ".agg_tmp", "node_modules", ".bin", "ajv");
+  const ajvCommand = fs.existsSync(localAjv)
+    ? `"${localAjv}"`
+    : "npx --yes --package ajv-cli ajv";
+
   const allReports = [];
   const processedFiles = [];
-  const schemaPath = "diagnostics.schema.json";
   let schemaFailures = 0;
   let schemaPasses = 0;
 
   function validateSchema(file) {
     try {
-      execSync(`npx ajv-cli validate -s ${schemaPath} -d ${file}`, { stdio: "pipe" });
+      execSync(`${ajvCommand} validate -s "${schemaPath}" -d "${file}"`, {
+        stdio: "pipe",
+        cwd: workspaceDir
+      });
       schemaPasses++;
       return null;
     } catch (e) {
@@ -27,33 +36,57 @@ try {
       const full = path.join(dir, entry.name);
       if (entry.isDirectory()) {
         loadFiles(full);
-      } else if (entry.name.endsWith("-diagnostics.json")) {
-        processedFiles.push(`✔️ Diagnostics: ${full}`);
-        try {
-          const data = JSON.parse(fs.readFileSync(full, "utf-8"));
-          data.__file = full;
-          const schemaError = validateSchema(full);
-          if (schemaError) {
-            data.schema_error = schemaError;
-            data.status = "failure";
-          }
-          allReports.push(data);
-        } catch (e) {
-          schemaFailures++;
-          allReports.push({ job: full, status: "failure", errors: 1, warnings: 0, messages: [{ type: "error", message: `Failed to parse diagnostics: ${e.message}` }], schema_error: e.toString() });
-        }
-      } else if (entry.name.endsWith("-fallback.json")) {
-        processedFiles.push(`⚠️ Fallback: ${full}`);
-        if (!allReports.some(r => r.__file && r.__file.includes(entry.name.replace("-fallback.json", "-diagnostics.json")))) {
+        continue;
+      }
+
+      if (!entry.name.endsWith(".json")) continue;
+
+      const rel = path.relative(workspaceDir, full) || entry.name;
+      const isFallback = entry.name.endsWith("-fallback.json");
+      if (isFallback) {
+        processedFiles.push(`⚠️ Fallback: ${rel}`);
+        const baseName = entry.name.replace("-fallback.json", "");
+        if (!allReports.some(r => r.__file && r.__file.includes(baseName))) {
           try {
             const data = JSON.parse(fs.readFileSync(full, "utf-8"));
-            data.__file = full;
+            data.__file = rel;
             data.fallback = true;
             allReports.push(data);
           } catch (e) {
-            allReports.push({ job: full, status: "failure", errors: 1, warnings: 0, messages: [{ type: "error", message: `Failed to parse fallback: ${e.message}` }] });
+            allReports.push({
+              job: rel,
+              status: "failure",
+              errors: 1,
+              warnings: 0,
+              messages: [{ type: "error", message: `Failed to parse fallback: ${e.message}` }]
+            });
           }
         }
+        continue;
+      }
+
+      processedFiles.push(`✔️ Summary: ${rel}`);
+      try {
+        const data = JSON.parse(fs.readFileSync(full, "utf-8"));
+        data.__file = rel;
+        const schemaError = validateSchema(full);
+        if (schemaError) {
+          data.schema_error = schemaError;
+          if (data.status !== "missing") {
+            data.status = "failure";
+          }
+        }
+        allReports.push(data);
+      } catch (e) {
+        schemaFailures++;
+        allReports.push({
+          job: rel,
+          status: "failure",
+          errors: 1,
+          warnings: 0,
+          messages: [{ type: "error", message: `Failed to parse diagnostics: ${e.message}` }],
+          schema_error: e.toString()
+        });
       }
     }
   }
@@ -61,55 +94,112 @@ try {
   loadFiles(baseDir);
 
   const expectedJobs = [
-    "frontend-checks/eslint",
-    "frontend-checks/prettier",
-    "frontend-checks/tsc",
-    "frontend-checks/jest-unit",
-    "frontend-checks/playwright-e2e",
-    "backend-checks/pytest",
-    "backend-checks/mypy",
-    "backend-checks/flake8",
-    "backend-checks/black",
-    "coverage-checks/frontend",
-    "coverage-checks/backend",
-    "coverage-checks/backend-node",
-    "coverage-checks/e2e"
+    "frontend-checks_lint",
+    "frontend-checks_prettier",
+    "frontend-checks_type-check",
+    "frontend-checks_test-unit",
+    "frontend-checks_playwright-e2e",
+    "backend-checks_black",
+    "backend-checks_flake8",
+    "backend-checks_mypy",
+    "backend-checks_pytest",
+    "coverage-checks_frontend",
+    "coverage-checks_backend",
+    "coverage-checks_backend-node",
+    "coverage-checks_e2e"
   ];
 
-  expectedJobs.forEach(job => {
-    if (!allReports.some(r => r.job === job)) {
-      allReports.push({ job, status: "missing", errors: 0, warnings: 0, messages: [{ type: "warning", message: "No diagnostics JSON uploaded" }] });
+  const expectedSet = new Set(expectedJobs);
+  const jobMap = new Map();
+  const extras = [];
+
+  for (const report of allReports) {
+    if (report.job && expectedSet.has(report.job) && !jobMap.has(report.job)) {
+      jobMap.set(report.job, report);
+    } else {
+      extras.push(report);
     }
+  }
+
+  const orderedReports = expectedJobs.map(job => {
+    if (jobMap.has(job)) return jobMap.get(job);
+    return {
+      job,
+      status: "missing",
+      exit_code: null,
+      errors: 0,
+      warnings: 1,
+      messages: [{ type: "warning", message: "No diagnostics JSON uploaded" }]
+    };
   });
+
+  const finalReports = [
+    ...orderedReports,
+    ...extras.filter(r => !expectedSet.has(r.job) || r.fallback)
+  ];
 
   let totalErrors = 0;
   let totalWarnings = 0;
-  let totalCoverageLines = { covered: 0, missed: 0 };
+  const totalCoverageLines = { covered: 0, missed: 0 };
 
-  let summaryTable = "### 📊 Summary Table\n\n| Job | Errors | Warnings | Status | Schema Valid |\n|-----|--------|----------|--------|--------------|\n";
-  let metadataTable = "\n### 🛠 Tool Metadata\n\n| Job | Tool | Version | Exit Code | Duration | Fallback |\n|-----|------|---------|-----------|----------|----------|\n";
+  let summaryTable = "### 📊 Summary Table\n\n| Job | Status | Exit Code | Schema Valid |\n|-----|--------|-----------|--------------|\n";
+  let metadataTable = "\n### 🛠 Tool Metadata\n\n| Job | Tool | Version | Runner | OS |\n|-----|------|---------|--------|----|\n";
 
   let errorsSection = "\n### ❌ Consolidated Errors\n";
   let warningsSection = "\n### ⚠️ Consolidated Warnings\n";
   let failedTestsSection = "\n### 🧨 Consolidated Test Failures\n";
-  let processedSection = "\n### 📂 Files Processed\n" + processedFiles.join("\n");
+  const processedList = processedFiles.length ? processedFiles.join("\n") : "No summary files discovered.";
+  const processedSection = "\n### 📂 Files Processed\n" + processedList;
+  const appendWarning = message => {
+    if (warningsSection.includes("_No warnings reported._")) {
+      warningsSection = warningsSection.replace("_No warnings reported._", "").trimEnd();
+    }
+    if (!warningsSection.endsWith("\n")) {
+      warningsSection += "\n";
+    }
+    warningsSection += `${message}\n`;
+  };
 
-  for (const r of allReports) {
-    const errors = Number.isInteger(r.errors) ? r.errors : (r.errors?.length || 0);
-    const warnings = Number.isInteger(r.warnings) ? r.warnings : (r.warnings?.length || 0);
+  for (const r of finalReports) {
+    const errors = Number.isInteger(r.errors)
+      ? r.errors
+      : (Array.isArray(r.errors) ? r.errors.length : 0);
+    const warnings = Number.isInteger(r.warnings)
+      ? r.warnings
+      : (Array.isArray(r.warnings) ? r.warnings.length : 0);
 
     totalErrors += errors;
     totalWarnings += warnings;
 
-    summaryTable += `| ${r.job || r.__file} | ${errors} | ${warnings} | ${r.status || "?"} | ${r.schema_error ? "❌" : "✅"} |\n`;
+    let exitCodeValue = null;
+    if (typeof r.exit_code === "number") {
+      exitCodeValue = r.exit_code;
+    } else if (typeof r.exit_code === "string" && r.exit_code.trim() !== "" && !Number.isNaN(Number(r.exit_code))) {
+      exitCodeValue = Number(r.exit_code);
+    }
+    const exitCodeDisplay = exitCodeValue ?? "?";
 
-    metadataTable += `| ${r.job || r.__file} | ${r.metadata?.tool || "?"} | ${r.metadata?.version || "?"} | ${r.exit_code ?? "?"} | ${r.metadata?.duration || "?"} | ${r.metadata?.fallback || false} |\n`;
+    let status = r.status || "?";
+    if (r.schema_error) {
+      status = "failure";
+    } else if (exitCodeValue !== null && status !== "missing") {
+      if (exitCodeValue !== 0 && status !== "failure") {
+        status = "failure";
+      }
+      if (exitCodeValue === 0 && status === "?") {
+        status = "success";
+      }
+    }
 
-    if (errors > 0) errorsSection += `- ${r.job}: ${errors} errors reported\n`;
-    if (warnings > 0) warningsSection += `- ${r.job}: ${warnings} warnings reported\n`;
+    summaryTable += `| ${r.job || r.__file || "unknown"} | ${status} | ${exitCodeDisplay} | ${r.schema_error ? "❌" : "✅"} |\n`;
+
+    metadataTable += `| ${r.job || r.__file || "unknown"} | ${r.metadata?.tool || "?"} | ${r.metadata?.version || "?"} | ${r.environment?.runner || "?"} | ${r.environment?.os || "?"} |\n`;
+
+    if (errors > 0) errorsSection += `- ${r.job || r.__file}: ${errors} errors reported\n`;
+    if (warnings > 0) warningsSection += `- ${r.job || r.__file}: ${warnings} warnings reported\n`;
     if (r.tests && r.tests.some(t => t.status === "failed")) {
       r.tests.filter(t => t.status === "failed").forEach(t => {
-        failedTestsSection += `- ${r.job}: ${t.name} → ${t.message || "failed"}\n`;
+        failedTestsSection += `- ${r.job || r.__file}: ${t.name} → ${t.message || "failed"}\n`;
       });
     }
 
@@ -125,23 +215,44 @@ try {
 
   let coverageSection = "\n### 📊 Coverage Summary\n";
   if (totalCoverageLines.covered + totalCoverageLines.missed > 0) {
-    const overallPct = (totalCoverageLines.covered / (totalCoverageLines.covered + totalCoverageLines.missed) * 100).toFixed(2);
-    coverageSection += `Overall Coverage: ${overallPct}% (${totalCoverageLines.covered}/${totalCoverageLines.covered + totalCoverageLines.missed} lines covered)\n`;
-    if (overallPct < 70) {
-      errorsSection += `\n⚠️ Coverage below threshold: ${overallPct}%\n`;
+    const total = totalCoverageLines.covered + totalCoverageLines.missed;
+    const overallPct = ((totalCoverageLines.covered / total) * 100).toFixed(2);
+    coverageSection += `Overall Coverage: ${overallPct}% (${totalCoverageLines.covered}/${total} lines covered)\n`;
+    if (Number(overallPct) < 70) {
+      appendWarning(`⚠️ Coverage below threshold: ${overallPct}%`);
       process.exitCode = 1;
     }
   } else {
     coverageSection += "No coverage data found.\n";
   }
 
-  const runUrl = `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
+  const runUrl = process.env.GITHUB_RUN_ID && process.env.GITHUB_REPOSITORY
+    ? `https://github.com/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`
+    : null;
 
-  const reportOut = `## ⚠️ CI Diagnostics Report\n\n${summaryTable}\n${metadataTable}\n${errorsSection}\n${warningsSection}\n${failedTestsSection}\n${coverageSection}\n${processedSection}\n\n🔗 [View workflow run](${runUrl})`;
-  fs.writeFileSync(path.join(process.env.GITHUB_WORKSPACE, "report.md"), reportOut);
-  fs.writeFileSync(path.join(process.env.GITHUB_WORKSPACE, "diagnostics-meta.json"), JSON.stringify({ totalErrors, totalWarnings, jobs: allReports.length, schemaFailures, schemaPasses, coverage: totalCoverageLines }, null, 2));
+  const reportOut = `## ⚠️ CI Diagnostics Report\n\n${summaryTable}\n${metadataTable}\n${errorsSection}\n${warningsSection}\n${failedTestsSection}\n${coverageSection}\n${processedSection}${runUrl ? `\n\n🔗 [View workflow run](${runUrl})` : ""}`;
 
+  fs.writeFileSync(path.join(workspaceDir, "report.md"), reportOut);
+  fs.writeFileSync(
+    path.join(workspaceDir, "diagnostics-meta.json"),
+    JSON.stringify(
+      {
+        totalErrors,
+        totalWarnings,
+        jobs: finalReports.length,
+        schemaFailures,
+        schemaPasses,
+        coverage: totalCoverageLines
+      },
+      null,
+      2
+    )
+  );
 } catch (err) {
-  fs.writeFileSync(path.join(process.env.GITHUB_WORKSPACE, "report.md"), `## ⚠️ Diagnostics Aggregator Error\n\n${err.message}`);
-  fs.writeFileSync(path.join(process.env.GITHUB_WORKSPACE, "diagnostics-meta.json"), JSON.stringify({ totalErrors: 0, totalWarnings: 0, jobs: 0, schemaFailures: 1, schemaPasses: 0 }, null, 2));
+  const workspaceDir = process.env.GITHUB_WORKSPACE || process.cwd();
+  fs.writeFileSync(path.join(workspaceDir, "report.md"), `## ⚠️ Diagnostics Aggregator Error\n\n${err.message}`);
+  fs.writeFileSync(
+    path.join(workspaceDir, "diagnostics-meta.json"),
+    JSON.stringify({ totalErrors: 0, totalWarnings: 0, jobs: 0, schemaFailures: 1, schemaPasses: 0 }, null, 2)
+  );
 }

--- a/.github/workflows/backend-checks.yml
+++ b/.github/workflows/backend-checks.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt pytest-json-report flake8 mypy black
+          pip install -r requirements.txt black flake8 mypy pytest pytest-cov
 
       - name: Collect environment metadata
         id: envinfo
@@ -38,20 +38,141 @@ jobs:
           echo "memory_mb=$(free -m | awk '/Mem:/ {print $2}')" >> $GITHUB_OUTPUT
           echo "disk_free_mb=$(df -m . | awk 'NR==2 {print $4}')" >> $GITHUB_OUTPUT
 
-      - name: Ensure summaries dir always exists
-        run: mkdir -p summaries
-
-      - name: Validate summaries before upload
-        if: always()
+      - name: Run ${{ matrix.task }}
+        id: run_task
+        continue-on-error: true
+        shell: bash
         run: |
-          echo "📂 Summaries before upload (${{ matrix.task }}):"
-          ls -lah summaries || echo "❌ summaries/ not found"
+          set -o pipefail
+          TASK="${{ matrix.task }}"
+          LOG_DIR="diagnostics/backend"
+          mkdir -p "$LOG_DIR"
+          LOG_FILE="$LOG_DIR/${TASK}_output.log"
+          TOOL_NAME="$TASK"
+          COMMAND=""
+          VERSION_CMD=""
+          case "$TASK" in
+            black)
+              COMMAND="black --check ."
+              VERSION_CMD="black --version"
+              ;;
+            flake8)
+              COMMAND="flake8 ."
+              VERSION_CMD="flake8 --version"
+              ;;
+            mypy)
+              COMMAND="mypy --config-file mypy.ini ."
+              VERSION_CMD="mypy --version"
+              ;;
+            pytest)
+              COMMAND="pytest --maxfail=20 --tb=short"
+              VERSION_CMD="pytest --version"
+              TOOL_NAME="pytest"
+              ;;
+            *)
+              echo "Unknown backend task: $TASK" >&2
+              echo "exit_code=1" >> "$GITHUB_OUTPUT"
+              echo "status=failure" >> "$GITHUB_OUTPUT"
+              exit 1
+              ;;
+          esac
 
-      - name: Upload backend summaries (unified)
+          RUNNER_INFO="${RUNNER_NAME:-Hosted Agent} (${RUNNER_OS:-ubuntu-latest})"
+          TOOL_VERSION="unknown"
+          if [ -n "$VERSION_CMD" ]; then
+            set +e
+            TOOL_VERSION=$(eval "$VERSION_CMD" 2>/dev/null | head -n 1)
+            if [ -z "$TOOL_VERSION" ]; then TOOL_VERSION="unknown"; fi
+            set -e
+          fi
+
+          echo "::group::${TASK}-diagnostics"
+          echo "::tool::${TOOL_NAME}"
+          echo "::version::${TOOL_VERSION}"
+          echo "::runner::${RUNNER_INFO}"
+
+          set +e
+          bash -c "$COMMAND" 2>&1 | tee "$LOG_FILE"
+          EXIT_CODE=${PIPESTATUS[0]}
+          set -e
+
+          echo "::exit_code::${EXIT_CODE}"
+          echo "::endgroup::"
+
+          STATUS="success"
+          if [ "$EXIT_CODE" -ne 0 ]; then STATUS="failure"; fi
+          printf 'exit_code=%s\n' "$EXIT_CODE" >> "$GITHUB_OUTPUT"
+          printf 'status=%s\n' "$STATUS" >> "$GITHUB_OUTPUT"
+          printf 'tool_version=%s\n' "$TOOL_VERSION" >> "$GITHUB_OUTPUT"
+          printf 'command=%s\n' "$COMMAND" >> "$GITHUB_OUTPUT"
+          printf 'log_file=%s\n' "$LOG_FILE" >> "$GITHUB_OUTPUT"
+
+      - name: Upload tool output log
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: backend-summaries
+          name: backend-${{ matrix.task }}-logs
+          path: ${{ steps.run_task.outputs.log_file }}
+          retention-days: 5
+          if-no-files-found: error
+
+      - name: 📦 Write diagnostics JSON
+        if: always()
+        shell: bash
+        run: |
+          SCOPE="backend"
+          JOB_KEY="backend-checks_${{ matrix.task }}"
+          EXIT_CODE="${{ steps.run_task.outputs.exit_code }}"
+          STATUS="${{ steps.run_task.outputs.status }}"
+          TOOL_VERSION="${{ steps.run_task.outputs.tool_version }}"
+          if [ -z "$EXIT_CODE" ] || ! [[ "$EXIT_CODE" =~ ^-?[0-9]+$ ]]; then EXIT_CODE=1; fi
+          if [ -z "$STATUS" ]; then STATUS="success"; fi
+          if [ "$EXIT_CODE" -ne 0 ]; then STATUS="failure"; fi
+          mkdir -p "summaries/$SCOPE"
+          RUNNER_LABEL="${RUNNER_NAME:-Hosted Agent}"
+          RUNNER_OS_LABEL="${RUNNER_OS:-ubuntu-latest}"
+          export JOB_KEY STATUS EXIT_CODE RUNNER_LABEL RUNNER_OS_LABEL
+          export TOOL_NAME="${{ matrix.task }}"
+          export TOOL_VERSION_VALUE="${TOOL_VERSION:-unknown}"
+          python - <<'PY' | tee "summaries/${SCOPE}/${JOB_KEY}.json"
+import json
+import os
+
+data = {
+    "job": os.environ["JOB_KEY"],
+    "status": os.environ["STATUS"],
+    "exit_code": int(os.environ.get("EXIT_CODE", "1")),
+    "metadata": {
+        "tool": os.environ["TOOL_NAME"],
+        "version": os.environ.get("TOOL_VERSION_VALUE", "unknown"),
+    },
+    "environment": {
+        "runner": os.environ.get("RUNNER_LABEL", "Hosted Agent"),
+        "os": os.environ.get("RUNNER_OS_LABEL", "ubuntu-latest"),
+    },
+    "dependencies": {
+        "npm": [],
+    },
+}
+
+print(json.dumps(data, indent=2))
+PY
+          ls -lah "summaries/$SCOPE"
+          cat "summaries/$SCOPE/${JOB_KEY}.json"
+          if [ ! -s "summaries/$SCOPE/${JOB_KEY}.json" ]; then
+            echo "Diagnostics summary missing for ${JOB_KEY}" >&2
+            exit 1
+          fi
+
+      - name: Upload diagnostics summary
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: diagnostics-summary-backend-checks_${{ matrix.task }}
           path: summaries/
           retention-days: 2
           if-no-files-found: error
+
+      - name: Fail job if task failed
+        if: ${{ always() && steps.run_task.outputs.exit_code != '0' }}
+        run: exit 1

--- a/.github/workflows/ci-diagnostics.yml
+++ b/.github/workflows/ci-diagnostics.yml
@@ -15,23 +15,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      - name: Download frontend summaries
+      - name: Download diagnostics summaries
         uses: actions/download-artifact@v4
         with:
-          name: frontend-summaries
-          path: ./summaries/frontend
-
-      - name: Download backend summaries
-        uses: actions/download-artifact@v4
-        with:
-          name: backend-summaries
-          path: ./summaries/backend
-
-      - name: Download coverage summaries
-        uses: actions/download-artifact@v4
-        with:
-          name: coverage-summaries
-          path: ./summaries/coverage
+          pattern: diagnostics-summary-*
+          path: .
+          merge-multiple: true
 
       - name: Install aggregator dependencies in isolated dir
         shell: bash

--- a/.github/workflows/coverage-checks.yml
+++ b/.github/workflows/coverage-checks.yml
@@ -46,12 +46,16 @@ jobs:
       - name: Install dependencies (pnpm)
         run: pnpm install
 
+      - name: Install Playwright browsers
+        if: ${{ matrix.task == 'e2e' }}
+        run: pnpm exec playwright install --with-deps
+
       - name: Install backend test dependencies
         if: ${{ matrix.task == 'backend' }}
         working-directory: backend
         run: |
           python -m pip install --upgrade pip
-          pip install -r $GITHUB_WORKSPACE/requirements.txt
+          pip install -r $GITHUB_WORKSPACE/requirements.txt pytest pytest-cov
 
       - name: Collect environment metadata
         id: envinfo
@@ -67,20 +71,197 @@ jobs:
           echo "memory_mb=$(free -m | awk '/Mem:/ {print $2}')" >> $GITHUB_OUTPUT
           echo "disk_free_mb=$(df -m . | awk 'NR==2 {print $4}')" >> $GITHUB_OUTPUT
 
-      - name: Ensure summaries dir always exists
-        run: mkdir -p summaries
-
-      - name: Validate summaries before upload
-        if: always()
+      - name: Run ${{ matrix.task }} coverage
+        id: run_task
+        continue-on-error: true
+        shell: bash
         run: |
-          echo "📂 Summaries before upload (${{ matrix.task }}):"
-          ls -lah summaries || echo "❌ summaries/ not found"
+          set -o pipefail
+          TASK="${{ matrix.task }}"
+          LOG_DIR="diagnostics/coverage/${TASK}"
+          mkdir -p "$LOG_DIR"
+          LOG_FILE="$LOG_DIR/${TASK}_output.log"
+          RUNNER_INFO="${RUNNER_NAME:-Hosted Agent} (${RUNNER_OS:-ubuntu-latest})"
+          TOOL_VERSION="unknown"
+          COMMAND_DESC=""
+          EXIT_CODE=0
 
-      - name: Upload coverage summaries (unified)
+          case "$TASK" in
+            frontend)
+              COMMAND_DESC="pnpm exec vitest run --coverage --coverage.reporter=lcov --coverage.reporter=text --coverage.reportsDirectory=coverage/frontend"
+              TOOL_VERSION=$(pnpm exec vitest --version 2>/dev/null | head -n 1 || echo "unknown")
+              echo "::group::frontend-coverage"
+              echo "::tool::vitest"
+              echo "::version::${TOOL_VERSION}"
+              echo "::runner::${RUNNER_INFO}"
+              set +e
+              pnpm exec vitest run --coverage --coverage.reporter=lcov --coverage.reporter=text --coverage.reportsDirectory=coverage/frontend 2>&1 | tee "$LOG_FILE"
+              EXIT_CODE=${PIPESTATUS[0]}
+              set -e
+              echo "::exit_code::${EXIT_CODE}"
+              echo "::endgroup::"
+              ;;
+            backend)
+              COMMAND_DESC="pytest --maxfail=20 --tb=short --cov=backend --cov-report=term --cov-report=xml --cov-report=html"
+              TOOL_VERSION=$(pytest --version 2>/dev/null | head -n 1 || echo "unknown")
+              echo "::group::backend-coverage"
+              echo "::tool::pytest"
+              echo "::version::${TOOL_VERSION}"
+              echo "::runner::${RUNNER_INFO}"
+              set +e
+              pytest --maxfail=20 --tb=short --cov=backend --cov-report=term --cov-report=xml --cov-report=html 2>&1 | tee "$LOG_FILE"
+              EXIT_CODE=${PIPESTATUS[0]}
+              set -e
+              echo "::exit_code::${EXIT_CODE}"
+              echo "::endgroup::"
+              ;;
+            backend-node)
+              COMMAND_DESC="pnpm exec jest --config backend/jest.config.cjs --coverage --coverageReporters=lcov --coverageDirectory=coverage/backend-node"
+              TOOL_VERSION=$(pnpm exec jest --version 2>/dev/null | head -n 1 || echo "unknown")
+              echo "::group::backend-node-coverage"
+              echo "::tool::jest"
+              echo "::version::${TOOL_VERSION}"
+              echo "::runner::${RUNNER_INFO}"
+              set +e
+              pnpm exec jest --config backend/jest.config.cjs --coverage --coverageReporters=lcov --coverageDirectory=coverage/backend-node 2>&1 | tee "$LOG_FILE"
+              EXIT_CODE=${PIPESTATUS[0]}
+              set -e
+              echo "::exit_code::${EXIT_CODE}"
+              echo "::endgroup::"
+              ;;
+            e2e)
+              COMMAND_DESC="pnpm exec playwright test --reporter=list --reporter=html"
+              TOOL_VERSION=$(pnpm exec playwright --version 2>/dev/null | head -n 1 || echo "unknown")
+              echo "::group::e2e-coverage"
+              echo "::tool::playwright"
+              echo "::version::${TOOL_VERSION}"
+              echo "::runner::${RUNNER_INFO}"
+              set +e
+              pnpm exec playwright test --reporter=list --reporter=html 2>&1 | tee "$LOG_FILE"
+              EXIT_CODE=${PIPESTATUS[0]}
+              set -e
+              echo "::exit_code::${EXIT_CODE}"
+              echo "::endgroup::"
+              ;;
+            *)
+              echo "Unknown coverage task: $TASK" >&2
+              echo "exit_code=1" >> "$GITHUB_OUTPUT"
+              echo "status=failure" >> "$GITHUB_OUTPUT"
+              exit 1
+              ;;
+          esac
+
+          STATUS="success"
+          if [ "$EXIT_CODE" -ne 0 ]; then STATUS="failure"; fi
+          printf 'exit_code=%s\n' "$EXIT_CODE" >> "$GITHUB_OUTPUT"
+          printf 'status=%s\n' "$STATUS" >> "$GITHUB_OUTPUT"
+          printf 'tool_version=%s\n' "$TOOL_VERSION" >> "$GITHUB_OUTPUT"
+          printf 'command=%s\n' "$COMMAND_DESC" >> "$GITHUB_OUTPUT"
+          printf 'log_file=%s\n' "$LOG_FILE" >> "$GITHUB_OUTPUT"
+          printf 'log_dir=%s\n' "$LOG_DIR" >> "$GITHUB_OUTPUT"
+
+      - name: Upload tool output log
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-summaries
+          name: coverage-${{ matrix.task }}-logs
+          path: ${{ steps.run_task.outputs.log_dir }}
+          retention-days: 5
+          if-no-files-found: error
+
+      - name: Upload coverage reports
+        if: always() && matrix.task == 'frontend'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-frontend-html
+          path: coverage/frontend
+          retention-days: 5
+          if-no-files-found: error
+
+      - name: Upload backend coverage HTML
+        if: always() && matrix.task == 'backend'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-backend-html
+          path: htmlcov
+          retention-days: 5
+          if-no-files-found: error
+
+      - name: Upload backend node coverage
+        if: always() && matrix.task == 'backend-node'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-backend-node-html
+          path: coverage/backend-node
+          retention-days: 5
+          if-no-files-found: error
+
+      - name: Upload e2e coverage report
+        if: always() && matrix.task == 'e2e'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-e2e-html
+          path: playwright-report
+          retention-days: 5
+          if-no-files-found: error
+
+      - name: 📦 Write diagnostics JSON
+        if: always()
+        shell: bash
+        run: |
+          SCOPE="coverage"
+          JOB_KEY="coverage-checks_${{ matrix.task }}"
+          EXIT_CODE="${{ steps.run_task.outputs.exit_code }}"
+          STATUS="${{ steps.run_task.outputs.status }}"
+          TOOL_VERSION="${{ steps.run_task.outputs.tool_version }}"
+          if [ -z "$EXIT_CODE" ] || ! [[ "$EXIT_CODE" =~ ^-?[0-9]+$ ]]; then EXIT_CODE=1; fi
+          if [ -z "$STATUS" ]; then STATUS="success"; fi
+          if [ "$EXIT_CODE" -ne 0 ]; then STATUS="failure"; fi
+          mkdir -p "summaries/$SCOPE"
+          RUNNER_LABEL="${RUNNER_NAME:-Hosted Agent}"
+          RUNNER_OS_LABEL="${RUNNER_OS:-ubuntu-latest}"
+          export JOB_KEY STATUS EXIT_CODE RUNNER_LABEL RUNNER_OS_LABEL
+          export TOOL_NAME="${{ matrix.task }}"
+          export TOOL_VERSION_VALUE="${TOOL_VERSION:-unknown}"
+          python - <<'PY' | tee "summaries/${SCOPE}/${JOB_KEY}.json"
+import json
+import os
+
+data = {
+    "job": os.environ["JOB_KEY"],
+    "status": os.environ["STATUS"],
+    "exit_code": int(os.environ.get("EXIT_CODE", "1")),
+    "metadata": {
+        "tool": os.environ["TOOL_NAME"],
+        "version": os.environ.get("TOOL_VERSION_VALUE", "unknown"),
+    },
+    "environment": {
+        "runner": os.environ.get("RUNNER_LABEL", "Hosted Agent"),
+        "os": os.environ.get("RUNNER_OS_LABEL", "ubuntu-latest"),
+    },
+    "dependencies": {
+        "npm": [],
+    },
+}
+
+print(json.dumps(data, indent=2))
+PY
+          ls -lah "summaries/$SCOPE"
+          cat "summaries/$SCOPE/${JOB_KEY}.json"
+          if [ ! -s "summaries/$SCOPE/${JOB_KEY}.json" ]; then
+            echo "Diagnostics summary missing for ${JOB_KEY}" >&2
+            exit 1
+          fi
+
+      - name: Upload diagnostics summary
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: diagnostics-summary-coverage-checks_${{ matrix.task }}
           path: summaries/
           retention-days: 2
           if-no-files-found: error
+
+      - name: Fail job if task failed
+        if: ${{ always() && steps.run_task.outputs.exit_code != '0' }}
+        run: exit 1

--- a/.github/workflows/frontend-checks.yml
+++ b/.github/workflows/frontend-checks.yml
@@ -31,33 +31,212 @@ jobs:
       - name: Install deps
         run: pnpm install --frozen-lockfile
 
-      - name: Run ${{ matrix.task }}
-        run: pnpm run checks:${{ matrix.task }}
+      - name: Install Playwright browsers
+        if: ${{ matrix.task == 'playwright-e2e' }}
+        run: pnpm exec playwright install --with-deps
 
-      - name: 📦 Write diagnostics JSON (if applicable)
-        if: matrix.task == 'playwright-e2e' || matrix.task == 'test-unit'
-        run: |
-          mkdir -p summaries/frontend
-          FILE="summaries/frontend/frontend-checks_${{ matrix.task }}.json"
-          echo "🧾 Writing summary for ${{ matrix.task }} to $FILE"
-          echo '{
-            "job": "frontend-checks/${{ matrix.task }}",
-            "status": "success",
-            "exit_code": 0,
-            "metadata": {"tool": "${{ matrix.task }}", "version": "1.0.0"},
-            "environment": {"runner": "Hosted Agent", "os": "ubuntu-latest"},
-            "dependencies": {"npm": []}
-          }' | tee "$FILE"
-          echo "📂 Listing contents:"
-          ls -lah summaries/frontend || echo "no summaries written"
-          echo "📄 JSON contents:" && cat "$FILE"
+      - name: Collect environment metadata
+        id: envinfo
         shell: bash
+        run: |
+          if [ -f pnpm-lock.yaml ]; then
+            echo "lockfile_sha=$(sha256sum pnpm-lock.yaml | awk '{print $1}')" >> "$GITHUB_OUTPUT"
+          else
+            echo "lockfile_sha=missing" >> "$GITHUB_OUTPUT"
+          fi
+          echo "cpu_count=$(nproc)" >> "$GITHUB_OUTPUT"
+          echo "memory_mb=$(free -m | awk '/Mem:/ {print $2}')" >> "$GITHUB_OUTPUT"
+          echo "disk_free_mb=$(df -m . | awk 'NR==2 {print $4}')" >> "$GITHUB_OUTPUT"
 
-      - name: 🚀 Upload summary (if applicable)
-        if: matrix.task == 'playwright-e2e' || matrix.task == 'test-unit'
+      - name: Run ${{ matrix.task }}
+        id: run_task
+        continue-on-error: true
+        shell: bash
+        run: |
+          set -o pipefail
+          TASK="${{ matrix.task }}"
+          LOG_DIR="diagnostics/frontend/${TASK}"
+          mkdir -p "$LOG_DIR"
+          PRIMARY_LOG="$LOG_DIR/${TASK}_output.log"
+          TOOL_NAME="$TASK"
+          COMMAND_DESC=""
+          TOOL_VERSION="unknown"
+          RUNNER_INFO="${RUNNER_NAME:-Hosted Agent} (${RUNNER_OS:-ubuntu-latest})"
+
+          case "$TASK" in
+            lint)
+              COMMAND_DESC="pnpm exec eslint . --ext .js,.ts,.tsx"
+              TOOL_VERSION=$(pnpm exec eslint --version 2>/dev/null | head -n 1 || echo "unknown")
+              echo "::group::eslint-diagnostics"
+              echo "::tool::eslint"
+              echo "::version::${TOOL_VERSION}"
+              echo "::runner::${RUNNER_INFO}"
+              set +e
+              pnpm exec eslint . --ext .js,.ts,.tsx 2>&1 | tee "$PRIMARY_LOG"
+              EXIT_CODE=${PIPESTATUS[0]}
+              set -e
+              echo "::exit_code::${EXIT_CODE}"
+              echo "::endgroup::"
+              ;;
+            prettier)
+              COMMAND_DESC="pnpm exec prettier --check ."
+              TOOL_VERSION=$(pnpm exec prettier --version 2>/dev/null | head -n 1 || echo "unknown")
+              echo "::group::prettier-diagnostics"
+              echo "::tool::prettier"
+              echo "::version::${TOOL_VERSION}"
+              echo "::runner::${RUNNER_INFO}"
+              set +e
+              pnpm exec prettier --check . 2>&1 | tee "$PRIMARY_LOG"
+              EXIT_CODE=${PIPESTATUS[0]}
+              set -e
+              echo "::exit_code::${EXIT_CODE}"
+              echo "::endgroup::"
+              ;;
+            type-check)
+              COMMAND_DESC="pnpm exec tsc --noEmit"
+              TOOL_VERSION=$(pnpm exec tsc --version 2>/dev/null | head -n 1 || echo "unknown")
+              echo "::group::tsc-diagnostics"
+              echo "::tool::tsc"
+              echo "::version::${TOOL_VERSION}"
+              echo "::runner::${RUNNER_INFO}"
+              set +e
+              pnpm exec tsc --noEmit 2>&1 | tee "$PRIMARY_LOG"
+              EXIT_CODE=${PIPESTATUS[0]}
+              set -e
+              echo "::exit_code::${EXIT_CODE}"
+              echo "::endgroup::"
+              ;;
+            test-unit)
+              COMMAND_DESC="pnpm exec vitest run --coverage && pnpm exec jest --coverage"
+              VITEST_VERSION=$(pnpm exec vitest --version 2>/dev/null | head -n 1 || echo "unknown")
+              JEST_VERSION=$(pnpm exec jest --version 2>/dev/null | head -n 1 || echo "unknown")
+              TOOL_VERSION="vitest ${VITEST_VERSION}; jest ${JEST_VERSION}"
+              VITEST_LOG="$LOG_DIR/vitest_output.log"
+              JEST_LOG="$LOG_DIR/jest_output.log"
+
+              echo "::group::vitest-diagnostics"
+              echo "::tool::vitest"
+              echo "::version::${VITEST_VERSION}"
+              echo "::runner::${RUNNER_INFO}"
+              set +e
+              pnpm exec vitest run --coverage 2>&1 | tee "$VITEST_LOG"
+              VITEST_EXIT=${PIPESTATUS[0]}
+              echo "::exit_code::${VITEST_EXIT}"
+              echo "::endgroup::"
+
+              echo "::group::jest-diagnostics"
+              echo "::tool::jest"
+              echo "::version::${JEST_VERSION}"
+              echo "::runner::${RUNNER_INFO}"
+              pnpm exec jest --coverage 2>&1 | tee "$JEST_LOG"
+              JEST_EXIT=${PIPESTATUS[0]}
+              set -e
+              echo "::exit_code::${JEST_EXIT}"
+              echo "::endgroup::"
+
+              EXIT_CODE=0
+              if [ "$VITEST_EXIT" -ne 0 ] || [ "$JEST_EXIT" -ne 0 ]; then EXIT_CODE=1; fi
+              PRIMARY_LOG="$VITEST_LOG"
+              printf 'secondary_log=%s\n' "$JEST_LOG" >> "$GITHUB_OUTPUT"
+              ;;
+            playwright-e2e)
+              COMMAND_DESC="pnpm exec playwright test"
+              TOOL_VERSION=$(pnpm exec playwright --version 2>/dev/null | head -n 1 || echo "unknown")
+              echo "::group::playwright-diagnostics"
+              echo "::tool::playwright"
+              echo "::version::${TOOL_VERSION}"
+              echo "::runner::${RUNNER_INFO}"
+              set +e
+              pnpm exec playwright test 2>&1 | tee "$PRIMARY_LOG"
+              EXIT_CODE=${PIPESTATUS[0]}
+              set -e
+              echo "::exit_code::${EXIT_CODE}"
+              echo "::endgroup::"
+              ;;
+            *)
+              echo "Unknown frontend task: $TASK" >&2
+              echo "exit_code=1" >> "$GITHUB_OUTPUT"
+              echo "status=failure" >> "$GITHUB_OUTPUT"
+              exit 1
+              ;;
+          esac
+
+          STATUS="success"
+          if [ -z "${EXIT_CODE+x}" ]; then EXIT_CODE=1; STATUS="failure"; fi
+          if [ "$EXIT_CODE" -ne 0 ]; then STATUS="failure"; fi
+          printf 'exit_code=%s\n' "$EXIT_CODE" >> "$GITHUB_OUTPUT"
+          printf 'status=%s\n' "$STATUS" >> "$GITHUB_OUTPUT"
+          printf 'tool_version=%s\n' "$TOOL_VERSION" >> "$GITHUB_OUTPUT"
+          printf 'command=%s\n' "$COMMAND_DESC" >> "$GITHUB_OUTPUT"
+          printf 'log_file=%s\n' "$PRIMARY_LOG" >> "$GITHUB_OUTPUT"
+          printf 'log_dir=%s\n' "$LOG_DIR" >> "$GITHUB_OUTPUT"
+
+      - name: Upload tool output log
+        if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: frontend-partial-${{ matrix.task }}
+          name: frontend-${{ matrix.task }}-logs
+          path: ${{ steps.run_task.outputs.log_dir }}
+          retention-days: 5
+          if-no-files-found: error
+
+      - name: 📦 Write diagnostics JSON
+        if: always()
+        shell: bash
+        run: |
+          SCOPE="frontend"
+          JOB_KEY="frontend-checks_${{ matrix.task }}"
+          EXIT_CODE="${{ steps.run_task.outputs.exit_code }}"
+          STATUS="${{ steps.run_task.outputs.status }}"
+          TOOL_VERSION="${{ steps.run_task.outputs.tool_version }}"
+          if [ -z "$EXIT_CODE" ] || ! [[ "$EXIT_CODE" =~ ^-?[0-9]+$ ]]; then EXIT_CODE=1; fi
+          if [ -z "$STATUS" ]; then STATUS="success"; fi
+          if [ "$EXIT_CODE" -ne 0 ]; then STATUS="failure"; fi
+          mkdir -p "summaries/$SCOPE"
+          RUNNER_LABEL="${RUNNER_NAME:-Hosted Agent}"
+          RUNNER_OS_LABEL="${RUNNER_OS:-ubuntu-latest}"
+          export JOB_KEY STATUS EXIT_CODE RUNNER_LABEL RUNNER_OS_LABEL
+          export TOOL_NAME="${{ matrix.task }}"
+          export TOOL_VERSION_VALUE="${TOOL_VERSION:-unknown}"
+          python - <<'PY' | tee "summaries/${SCOPE}/${JOB_KEY}.json"
+import json
+import os
+
+data = {
+    "job": os.environ["JOB_KEY"],
+    "status": os.environ["STATUS"],
+    "exit_code": int(os.environ.get("EXIT_CODE", "1")),
+    "metadata": {
+        "tool": os.environ["TOOL_NAME"],
+        "version": os.environ.get("TOOL_VERSION_VALUE", "unknown"),
+    },
+    "environment": {
+        "runner": os.environ.get("RUNNER_LABEL", "Hosted Agent"),
+        "os": os.environ.get("RUNNER_OS_LABEL", "ubuntu-latest"),
+    },
+    "dependencies": {
+        "npm": [],
+    },
+}
+
+print(json.dumps(data, indent=2))
+PY
+          ls -lah "summaries/$SCOPE"
+          cat "summaries/$SCOPE/${JOB_KEY}.json"
+          if [ ! -s "summaries/$SCOPE/${JOB_KEY}.json" ]; then
+            echo "Diagnostics summary missing for ${JOB_KEY}" >&2
+            exit 1
+          fi
+
+      - name: Upload diagnostics summary
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: diagnostics-summary-frontend-checks_${{ matrix.task }}
           path: summaries/
           retention-days: 2
           if-no-files-found: error
+
+      - name: Fail job if task failed
+        if: ${{ always() && steps.run_task.outputs.exit_code != '0' }}
+        run: exit 1

--- a/diagnostics.schema.json
+++ b/diagnostics.schema.json
@@ -1,157 +1,45 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "Diagnostics Schema",
+  "title": "Diagnostics Summary",
   "type": "object",
   "required": [
     "job",
-    "exit_code",
     "status",
-    "errors",
-    "warnings",
-    "artifacts",
+    "exit_code",
     "metadata",
-    "environment"
+    "environment",
+    "dependencies"
   ],
   "properties": {
     "job": { "type": "string" },
-    "exit_code": { "type": "integer" },
     "status": { "type": "string", "enum": ["success", "failure", "warning", "skipped"] },
-    "errors": { "type": "integer", "minimum": 0 },
-    "warnings": { "type": "integer", "minimum": 0 },
-    "messages": {
-      "type": "array",
-      "description": "Detailed messages from tool outputs",
-      "items": {
-        "type": "object",
-        "required": ["type", "message"],
-        "properties": {
-          "type": { "type": "string", "enum": ["error", "warning", "notice"] },
-          "message": { "type": "string" },
-          "file": { "type": "string" },
-          "line": { "type": "integer" },
-          "column": { "type": "integer" },
-          "rule": { "type": "string" },
-          "stack": { "type": "string" }
-        }
-      }
-    },
-    "annotations": {
-      "type": "array",
-      "description": "Annotations pulled from GitHub Actions API",
-      "items": {
-        "type": "object",
-        "properties": {
-          "annotation_level": { "type": "string", "enum": ["failure", "warning", "notice"] },
-          "message": { "type": "string" },
-          "path": { "type": "string" },
-          "start_line": { "type": "integer" },
-          "end_line": { "type": "integer" },
-          "title": { "type": "string" }
-        }
-      }
-    },
-    "tests": {
-      "type": "array",
-      "description": "Detailed test case results",
-      "items": {
-        "type": "object",
-        "required": ["name", "status"],
-        "properties": {
-          "name": { "type": "string" },
-          "status": { "type": "string", "enum": ["passed", "failed", "skipped"] },
-          "duration": { "type": "string" },
-          "message": { "type": "string" },
-          "file": { "type": "string" },
-          "line": { "type": "integer" },
-          "stack": { "type": "string" }
-        }
-      }
-    },
-    "coverage": {
-      "type": "object",
-      "description": "Coverage details per job",
-      "properties": {
-        "lines": {
-          "type": "object",
-          "properties": {
-            "covered": { "type": "integer" },
-            "missed": { "type": "integer" },
-            "pct": { "type": "number" }
-          }
-        },
-        "branches": {
-          "type": "object",
-          "properties": {
-            "covered": { "type": "integer" },
-            "missed": { "type": "integer" },
-            "pct": { "type": "number" }
-          }
-        },
-        "files": {
-          "type": "array",
-          "items": {
-            "type": "object",
-            "properties": {
-              "path": { "type": "string" },
-              "lines_pct": { "type": "number" },
-              "branches_pct": { "type": "number" }
-            }
-          }
-        }
-      }
-    },
-    "artifacts": {
-      "type": "array",
-      "items": {
-        "type": "object",
-        "required": ["name", "path"],
-        "properties": {
-          "name": { "type": "string" },
-          "path": { "type": "string" },
-          "url": { "type": "string" }
-        }
-      }
-    },
+    "exit_code": { "type": "integer" },
     "metadata": {
       "type": "object",
+      "required": ["tool", "version"],
       "properties": {
         "tool": { "type": "string" },
-        "version": { "type": "string" },
-        "duration": { "type": "string" },
-        "sha256": { "type": "string" },
-        "fallback": { "type": "boolean" }
+        "version": { "type": "string" }
       }
     },
     "environment": {
       "type": "object",
+      "required": ["runner", "os"],
       "properties": {
         "runner": { "type": "string" },
-        "os": { "type": "string" },
-        "node": { "type": "string" },
-        "python": { "type": "string" },
-        "pnpm": { "type": "string" },
-        "git_sha": { "type": "string" },
-        "job_started": { "type": "string", "format": "date-time" },
-        "job_ended": { "type": "string", "format": "date-time" }
+        "os": { "type": "string" }
       }
     },
     "dependencies": {
       "type": "object",
-      "description": "Snapshot of dependencies and lockfile",
+      "required": ["npm"],
       "properties": {
-        "lockfile_sha": { "type": "string" },
-        "npm": { "type": "object" },
-        "pip": { "type": "object" }
-      }
-    },
-    "resources": {
-      "type": "object",
-      "description": "System resource info",
-      "properties": {
-        "cpu_count": { "type": "integer" },
-        "memory_mb": { "type": "integer" },
-        "disk_free_mb": { "type": "integer" }
+        "npm": {
+          "type": "array",
+          "items": { "type": "string" }
+        }
       }
     }
-  }
+  },
+  "additionalProperties": true
 }

--- a/tasks/diagnostics-summary-integration.task.md
+++ b/tasks/diagnostics-summary-integration.task.md
@@ -1,0 +1,55 @@
+# Diagnostics Summary Integration Contract
+
+This task defines the canonical requirements for Codex-compatible diagnostics summaries across the CI matrices. Every update to the diagnostics system must continue to satisfy these expectations.
+
+## Matrix Coverage
+
+The following jobs MUST emit diagnostics summaries:
+
+- **frontend-checks**: `lint`, `prettier`, `type-check`, `test-unit`, `playwright-e2e`
+- **backend-checks**: `black`, `flake8`, `mypy`, `pytest`
+- **coverage-checks**: `frontend`, `backend`, `backend-node`, `e2e`
+
+## Summary File Specification
+
+For each matrix entry, the workflow must:
+
+1. Create `summaries/<scope>` where `<scope>` is `frontend`, `backend`, or `coverage`.
+2. Write a JSON summary at `summaries/<scope>/<job-key>.json` where `<job-key>` matches the aggregator key (for example `frontend-checks_lint`).
+3. The JSON content must match the schema:
+
+```json
+{
+  "job": "<job-key>",
+  "status": "success",
+  "exit_code": 0,
+  "metadata": {
+    "tool": "<task>",
+    "version": "1.0.0"
+  },
+  "environment": {
+    "runner": "Hosted Agent",
+    "os": "ubuntu-latest"
+  },
+  "dependencies": {
+    "npm": []
+  }
+}
+```
+
+4. Write the file via `tee` (for example `cat <<'EOF' | tee summaries/<scope>/<job-key>.json`).
+5. Display the directory listing (`ls -lah summaries/<scope>`) and the file contents (`cat summaries/<scope>/<job-key>.json`).
+6. Upload the entire `summaries/` directory as an artifact named `diagnostics-summary-<job-key>` with a two-day retention window.
+
+## Aggregator Expectations
+
+- The diagnostics aggregator loads each JSON file, validates it against `diagnostics.schema.json`, and renders the CI Diagnostics Report.
+- Missing or invalid summaries surface as explicit warnings; no implicit fallbacks should be relied upon.
+- Artifact download patterns in `.github/workflows/diagnostics.yml` must continue to capture every `diagnostics-summary-*` artifact.
+
+## Extensibility Guidance
+
+- Adding a new matrix entry requires updating the workflow summary emission and the aggregator's expected job list.
+- Schema changes must remain backward compatible or include appropriate migration logic in the aggregator.
+- Keep the summary writer logic modular so that additional metadata fields can be added in the future without breaking the base schema above.
+


### PR DESCRIPTION
## Summary
- update backend, frontend, and coverage matrix jobs to emit schema-compliant diagnostics JSON via tee and upload per-job artifacts named after each diagnostics key
- ensure each summary captures job metadata (tool, version, runner, os) with standardized success/failure handling so the aggregator ingests the real matrix results
- document the canonical diagnostics-summary integration contract for future contributors in `tasks/diagnostics-summary-integration.task.md`

## Testing
- ⚠️ not run (workflow-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68d17927162883218dbf9892a3d69f79